### PR TITLE
add: ローディング用のトーク履歴をレスポンスに追加

### DIFF
--- a/app.py
+++ b/app.py
@@ -23,6 +23,7 @@ def word_ranking(file):
     talk_list = talk.split()
 
     # トーク履歴から会話内容を抽出
+    # ランキング作成用の会話内容を抽出
     talk_put_together = ''
     time_pattern = re.compile(r"\d{1,2}:\d{2}")
     week_pattern = re.compile(r"(月|火|水|木|金|土|日)曜日")
@@ -34,6 +35,20 @@ def word_ranking(file):
 
         if time_match and not(week_match):
             talk_put_together += talk_list[i-1]
+
+    # ローディング用の会話内容を抽出
+    serial_talk = []
+
+    for i in range(1, len(talk_list)):
+        time_match = re.search(time_pattern, talk_list[i])
+        week_match = re.search(week_pattern, talk_list[i-1]) or re.search(abbr_week_pattern, talk_list[i-1])
+
+        if time_match and not(week_match):
+            if 'トーク履歴' in talk_list[i-2]:
+                continue
+            serial_talk.append([talk_list[i-2], talk_list[i-1]])
+            if len(serial_talk)==10:
+                break
 
     # 会話内容から英数字と特殊記号を削除
     alphanumeric_pattern = re.compile('[a-zA-Z0-9]+')
@@ -72,21 +87,28 @@ def word_ranking(file):
 
     # トップ10が作成できる場合はランキングを返す
     if len(ranking)>=10:
-        top_10 = ranking[0:10]
-
-        # トップ10をjson形式に変換
-        content = []
+        # トップ10＆ローディング用の会話内容をjson形式に変換
+        top_10_list = []
+        serial_talk_list = []
 
         for i in range(10):
-            dict_data = {
+            top_10_dict = {
               'rank': i+1,
-              'word': top_10[i][0],
-              'num_of_use': top_10[i][1]
+              'word': ranking[i][0],
+              'num_of_use': ranking[i][1]
             }
-            content.append(dict_data)
 
-        top_10_json = json.dumps(content, ensure_ascii=False)
-        return jsonify({'content': top_10_json})
+            serial_talk_dict = {
+              'name': serial_talk[i][0],
+              'talk': serial_talk[i][1]
+            }
+
+            top_10_list.append(top_10_dict)
+            serial_talk_list.append(serial_talk_dict)
+
+        top_10_json = json.dumps(top_10_list, ensure_ascii=False)
+        serial_talk_json = json.dumps(serial_talk_list, ensure_ascii=False)
+        return jsonify({'top_10': top_10_json, 'serial_talk': serial_talk_json})
 
     # トップ10が作成できない場合はランキングを返さない
     not_enough = 'ランキングを作成するのに十分な会話をしていないようです。'


### PR DESCRIPTION
# やったこと
- アプリのローディング中に使用する、連続した10件のトーク履歴をレスポンスに追加した

# その他
- 今更だけど、このAPIはLINEの設定言語を日本語以外にしている人が使うとうまく前処理ができないので、日本語ネイティブなのに設定言語を別のにしている人は使えない